### PR TITLE
Add mesos-slave versions 0.25.0 and 0.26.0 for Centos 7 and Ubuntu 14.04

### DIFF
--- a/.monty.yml
+++ b/.monty.yml
@@ -1,9 +1,31 @@
+- build: 0.26.0/centos/7
+  image:
+    - mesoscloud/mesos-slave:0.26.0-centos-7
+    - mesoscloud/mesos-slave:0.26.0-centos
+    - mesoscloud/mesos-slave:0.26.0
+    - mesoscloud/mesos-slave:latest
+
+- build: 0.26.0/ubuntu/14.04
+  image:
+    - mesoscloud/mesos-slave:0.26.0-ubuntu-14.04
+    - mesoscloud/mesos-slave:0.26.0-ubuntu
+
+- build: 0.25.0/centos/7
+  image:
+    - mesoscloud/mesos-slave:0.25.0-centos-7
+    - mesoscloud/mesos-slave:0.25.0-centos
+    - mesoscloud/mesos-slave:0.25.0
+
+- build: 0.25.0/ubuntu/14.04
+  image:
+    - mesoscloud/mesos-slave:0.25.0-ubuntu-14.04
+    - mesoscloud/mesos-slave:0.25.0-ubuntu
+
 - build: 0.24.1/centos/7
   image:
     - mesoscloud/mesos-slave:0.24.1-centos-7
     - mesoscloud/mesos-slave:0.24.1-centos
     - mesoscloud/mesos-slave:0.24.1
-    - mesoscloud/mesos-slave:latest
 
 - build: 0.24.1/ubuntu/14.04
   image:

--- a/0.25.0/centos/7/Dockerfile
+++ b/0.25.0/centos/7/Dockerfile
@@ -1,0 +1,24 @@
+FROM centos:7
+
+RUN rpm -i http://repos.mesosphere.io/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm && \
+yum -y install mesos-0.25.0
+
+# http://docs.docker.com/installation/centos/
+RUN curl -fLsS https://get.docker.com/ | sh
+
+CMD ["/usr/sbin/mesos-slave"]
+
+ENV MESOS_WORK_DIR /tmp/mesos
+ENV MESOS_CONTAINERIZERS docker,mesos
+
+# https://mesosphere.github.io/marathon/docs/native-docker.html
+ENV MESOS_EXECUTOR_REGISTRATION_TIMEOUT 5mins
+
+# https://issues.apache.org/jira/browse/MESOS-3793
+ENV MESOS_LAUNCHER posix
+
+VOLUME /tmp/mesos
+
+COPY entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/0.25.0/centos/7/entrypoint.sh
+++ b/0.25.0/centos/7/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+PRINCIPAL=${PRINCIPAL:-root}
+
+if [ -n "$SECRET" ]; then
+    touch /tmp/credential
+    chmod 600 /tmp/credential
+    echo -n "$PRINCIPAL $SECRET" > /tmp/credential
+    export MESOS_CREDENTIAL=/tmp/credential
+fi
+
+exec "$@"

--- a/0.25.0/ubuntu/14.04/Dockerfile
+++ b/0.25.0/ubuntu/14.04/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:14.04
+
+RUN apt-get update && \
+apt-get install -y curl
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
+echo deb http://repos.mesosphere.io/ubuntu trusty main > /etc/apt/sources.list.d/mesosphere.list && \
+apt-get update && \
+apt-get -y install mesos=0.25.0-0.2.70.ubuntu1404
+
+# http://docs.docker.com/installation/ubuntulinux/
+RUN curl -fLsS https://get.docker.com/ | sh
+
+CMD ["/usr/sbin/mesos-slave"]
+
+ENV MESOS_WORK_DIR /tmp/mesos
+ENV MESOS_CONTAINERIZERS docker,mesos
+
+# https://mesosphere.github.io/marathon/docs/native-docker.html
+ENV MESOS_EXECUTOR_REGISTRATION_TIMEOUT 5mins
+
+# https://issues.apache.org/jira/browse/MESOS-3793
+ENV MESOS_LAUNCHER posix
+
+VOLUME /tmp/mesos
+
+COPY entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/0.25.0/ubuntu/14.04/entrypoint.sh
+++ b/0.25.0/ubuntu/14.04/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+PRINCIPAL=${PRINCIPAL:-root}
+
+if [ -n "$SECRET" ]; then
+    touch /tmp/credential
+    chmod 600 /tmp/credential
+    echo -n "$PRINCIPAL $SECRET" > /tmp/credential
+    export MESOS_CREDENTIAL=/tmp/credential
+fi
+
+exec "$@"

--- a/0.26.0/centos/7/Dockerfile
+++ b/0.26.0/centos/7/Dockerfile
@@ -1,0 +1,24 @@
+FROM centos:7
+
+RUN rpm -i http://repos.mesosphere.io/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm && \
+yum -y install mesos-0.26.0
+
+# http://docs.docker.com/installation/centos/
+RUN curl -fLsS https://get.docker.com/ | sh
+
+CMD ["/usr/sbin/mesos-slave"]
+
+ENV MESOS_WORK_DIR /tmp/mesos
+ENV MESOS_CONTAINERIZERS docker,mesos
+
+# https://mesosphere.github.io/marathon/docs/native-docker.html
+ENV MESOS_EXECUTOR_REGISTRATION_TIMEOUT 5mins
+
+# https://issues.apache.org/jira/browse/MESOS-3793
+ENV MESOS_LAUNCHER posix
+
+VOLUME /tmp/mesos
+
+COPY entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/0.26.0/centos/7/entrypoint.sh
+++ b/0.26.0/centos/7/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+PRINCIPAL=${PRINCIPAL:-root}
+
+if [ -n "$SECRET" ]; then
+    touch /tmp/credential
+    chmod 600 /tmp/credential
+    echo -n "$PRINCIPAL $SECRET" > /tmp/credential
+    export MESOS_CREDENTIAL=/tmp/credential
+fi
+
+exec "$@"

--- a/0.26.0/ubuntu/14.04/Dockerfile
+++ b/0.26.0/ubuntu/14.04/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:14.04
+
+RUN apt-get update && \
+apt-get install -y curl
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
+echo deb http://repos.mesosphere.io/ubuntu trusty main > /etc/apt/sources.list.d/mesosphere.list && \
+apt-get update && \
+apt-get -y install mesos=0.26.0-0.2.145.ubuntu1404
+
+# http://docs.docker.com/installation/ubuntulinux/
+RUN curl -fLsS https://get.docker.com/ | sh
+
+CMD ["/usr/sbin/mesos-slave"]
+
+ENV MESOS_WORK_DIR /tmp/mesos
+ENV MESOS_CONTAINERIZERS docker,mesos
+
+# https://mesosphere.github.io/marathon/docs/native-docker.html
+ENV MESOS_EXECUTOR_REGISTRATION_TIMEOUT 5mins
+
+# https://issues.apache.org/jira/browse/MESOS-3793
+ENV MESOS_LAUNCHER posix
+
+VOLUME /tmp/mesos
+
+COPY entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/0.26.0/ubuntu/14.04/entrypoint.sh
+++ b/0.26.0/ubuntu/14.04/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+PRINCIPAL=${PRINCIPAL:-root}
+
+if [ -n "$SECRET" ]; then
+    touch /tmp/credential
+    chmod 600 /tmp/credential
+    echo -n "$PRINCIPAL $SECRET" > /tmp/credential
+    export MESOS_CREDENTIAL=/tmp/credential
+fi
+
+exec "$@"


### PR DESCRIPTION
Hi --

I added support for mesos-slave version 0.25.0 and 0.26.0 for both CentOS 7 and Ubuntu 14.04.

Thanks!

Kevin
